### PR TITLE
Use httpredir instead of hardcoded ac.uk mirror

### DIFF
--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:8.3
 MAINTAINER Arachnys <techteam@arachnys.com>
 
-RUN echo 'deb http://debian.man.ac.uk/debian/ stable main contrib non-free' >> /etc/apt/sources.list
+RUN echo 'deb http://httpredir.debian.org/debian/ stable main contrib non-free' >> /etc/apt/sources.list
 
 RUN apt-get -yq update && \
     apt-get -yq install \


### PR DESCRIPTION
"If you don't know which mirror to use or your system moves around a lot, you can use the mirror redirector service in your apt sources.list. It dynamically redirects package download requests to the best mirror available based on a number of factors such as mirror availability, location, architecture and freshness. "

From http://debian.org/mirror/list