### PR TITLE
Fix app not exiting when data is unbuffered

### DIFF
--- a/cli/src/athenapdf.js
+++ b/cli/src/athenapdf.js
@@ -98,8 +98,7 @@ const _complete = () => {
 const _output = (data) => {
     const outputPath = path.join(process.cwd(), outputArg);
     if (athena.stdout) {
-        let ok = process.stdout.write(data);
-        process.stdout.on("drain", _complete);
+        process.stdout.write(data, _complete);
     } else {
         fs.writeFile(outputPath, data, (err) => {
             if (err) console.error(err);


### PR DESCRIPTION
This commit uses the `write` stream callback
to wait until the stream is drained before
exiting.

---

Related to: a03308ddf44740f5bf14ff1965b2754d0feed259 and https://github.com/arachnys/athenapdf/commit/a4c2c465e22c5c7f58429afc9dcf1a4d876aa159.

I haven't merged this yet because I'm running some tests locally.

**Test URLs:**

- https://whispersystems.org/blog/whatsapp-complete/
- http://blog.invisionapp.com/inside-design-wework/
- https://askwonder.com/q/what-big-things-happened-to-time-warner-in-1q2016-part-ii-5706931886302e340038609d

