### PR TITLE
Handle piping html directly via stdin

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -25,13 +25,10 @@
   },
   "dependencies": {
     "commander": "^2.9.0",
-<<<<<<< HEAD
     "electron-prebuilt": "^0.37.6",
     "rw": "^1.3.2",
     "temp": "^0.8.3"
-=======
     "electron-prebuilt": "^0.37.6"
->>>>>>> upstream/master
   },
   "devDependencies": {
     "electron-packager": "^6.0.0"

--- a/cli/package.json
+++ b/cli/package.json
@@ -25,7 +25,9 @@
   },
   "dependencies": {
     "commander": "^2.9.0",
-    "electron-prebuilt": "^0.37.5"
+    "electron-prebuilt": "^0.37.5",
+    "rw": "^1.3.2",
+    "temp": "^0.8.3"
   },
   "devDependencies": {
     "electron-packager": "^6.0.0"

--- a/cli/package.json
+++ b/cli/package.json
@@ -27,8 +27,7 @@
     "commander": "^2.9.0",
     "electron-prebuilt": "^0.37.6",
     "rw": "^1.3.2",
-    "temp": "^0.8.3",
-    "electron-prebuilt": "^0.37.6"
+    "temp": "^0.8.3"
   },
   "devDependencies": {
     "electron-packager": "^6.0.0"

--- a/cli/package.json
+++ b/cli/package.json
@@ -27,7 +27,7 @@
     "commander": "^2.9.0",
     "electron-prebuilt": "^0.37.6",
     "rw": "^1.3.2",
-    "temp": "^0.8.3"
+    "temp": "^0.8.3",
     "electron-prebuilt": "^0.37.6"
   },
   "devDependencies": {

--- a/cli/src/athenapdf.js
+++ b/cli/src/athenapdf.js
@@ -4,6 +4,8 @@ const fs = require("fs");
 const crypto = require("crypto");
 const path = require("path");
 const url = require("url");
+const temp = require("temp").track();
+const rw = require("rw");
 
 const athena = require("commander");
 const electron = require("electron");
@@ -44,6 +46,15 @@ if (!process.argv.slice(2).length) {
 if (!uriArg) {
     console.error("No URI given.");
     process.exit(1);
+}
+
+// Handle stdin
+if (uriArg === '-') {
+	const tmpFileInfo = temp.openSync('athena');
+	var html = rw.readFileSync("/dev/stdin", "utf8");
+	fs.writeSync(tmpFileInfo.fd, html);
+	fs.closeSync(tmpFileInfo.fd);
+	uriArg = tmpFileInfo.path;
 }
 
 // Handle local paths


### PR DESCRIPTION
Patch for https://github.com/arachnys/athenapdf/issues/13

Passing `-` instead of a file or URL will now read from stdin

Using temporary files seems to be necessary here - from what I can see, Electron's browser window does not have an API for loading arbitrary HTML from a string.

Also, the `docker run` command requires the -i flag for this to work, otherwise it will produce a blank PDF output.