### PR TITLE
Remove redundant layers in docker image

### DIFF
--- a/weaver/Dockerfile
+++ b/weaver/Dockerfile
@@ -3,9 +3,11 @@ MAINTAINER Arachnys <techteam@arachnys.com>
 
 ENV GIN_MODE release
 
-RUN wget https://github.com/Yelp/dumb-init/releases/download/v1.0.0/dumb-init_1.0.0_amd64.deb
-RUN dpkg -i dumb-init_*.deb
-RUN rm dumb-init_*.deb
+RUN \
+  wget https://github.com/Yelp/dumb-init/releases/download/v1.0.0/dumb-init_1.0.0_amd64.deb \
+  && dpkg -i dumb-init_*.deb \
+  && rm dumb-init_*.deb \
+  ;
 
 RUN mkdir -p /athenapdf-service/tmp/
 ADD build/weaver /athenapdf-service/


### PR DESCRIPTION
The current structure of the Dockerfile means that anyone pulling this image still has to download the dumb-init package file, rather than just the post-install layer diff. This change flattens those 3 layers into 1.