### PR TITLE
Add support for Ethiopian font, and use Liberation font family on Linux

### DIFF
--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -5,19 +5,20 @@ RUN echo 'deb http://httpredir.debian.org/debian/ stable main contrib non-free' 
 
 RUN apt-get -yq update && \
     apt-get -yq install \
+        wget \
         xvfb \
         libgtk2.0-0 \
         libgconf-2-4 \
         libXtst6 \
         libnss3 \
         libnotify4 \
-        ttf-mscorefonts-installer \
-        ttf-liberation \
-        ttf-wqy-zenhei \
-        ttf-unfonts-core \
-        fonts-sil-padauk \
         fonts-lklug-sinhala \
+        fonts-sil-abyssinica \
+        fonts-sil-padauk \
         fonts-thai-tlwg \
+        ttf-liberation \
+        ttf-unfonts-core \
+        ttf-wqy-zenhei \
     && apt-get -yq autoremove \
     && apt-get -yq clean \
     && rm -rf /var/lib/apt/lists/* \

--- a/cli/src/athenapdf.js
+++ b/cli/src/athenapdf.js
@@ -83,13 +83,22 @@ if (athena.proxy) {
 }
 
 // Preferences
-const bwOpts = {
+var bwOpts = {
     show: (athena.debug || false),
     webPreferences: {
         nodeIntegration: false,
         webSecurity: false
     }
 };
+
+if (process.platform === "linux") {
+    bwOpts["webPreferences"]["defaultFontFamily"] = {
+        standard: "Liberation Serif",
+        serif: "Liberation Serif",
+        sansSerif: "Liberation Sans",
+        monospace: "Liberation Mono"
+    };
+}
 
 const loadOpts = {
     "extraHeaders": athena.cache ? "" : "pragma: no-cache\n"


### PR DESCRIPTION
This should:

- Shrink the Docker image size (because we're removing `ttf-mscorefonts-installer`)
- Switch to Liberation font family for Linux (most distros supports it by default)
- Add support for Ethiopian (addresses https://github.com/arachnys/athenapdf/pull/22#issuecomment-215180452)

Oh, and we're installing `wget` because for some reason it is no longer available.

cc: @arachnys/qa 