### PR TITLE
Fix a bug where a local conversion fails on a fallback due to GC

### DIFF
--- a/weaver/converter/athenapdf/athenapdf.go
+++ b/weaver/converter/athenapdf/athenapdf.go
@@ -4,7 +4,6 @@ import (
 	"github.com/arachnys/athenapdf/weaver/converter"
 	"github.com/arachnys/athenapdf/weaver/gcmd"
 	"log"
-	"os"
 	"strings"
 )
 
@@ -43,11 +42,6 @@ func constructCMD(base string, path string, aggressive bool) []string {
 // using athenapdf CLI.
 // See the Convert method for Conversion for more information.
 func (c AthenaPDF) Convert(s converter.ConversionSource, done <-chan struct{}) ([]byte, error) {
-	// GC if converting temporary file
-	if s.IsLocal {
-		defer os.Remove(s.URI)
-	}
-
 	log.Printf("[AthenaPDF] converting to PDF: %s\n", s.GetActualURI())
 
 	// Construct the command to execute

--- a/weaver/converter/athenapdf/athenapdf_test.go
+++ b/weaver/converter/athenapdf/athenapdf_test.go
@@ -4,7 +4,6 @@ import (
 	"github.com/arachnys/athenapdf/weaver/converter"
 	"github.com/arachnys/athenapdf/weaver/testutil"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -62,9 +61,6 @@ func TestConvert_local(t *testing.T) {
 	}
 	if want := []byte(p + "\n"); !reflect.DeepEqual(got, want) {
 		t.Errorf("expected output of athenapdf conversion to be %s, got %s", want, got)
-	}
-	if _, err := os.Stat(p); !os.IsNotExist(err) {
-		t.Errorf("expected temporary file to be removed after local conversion")
 	}
 }
 

--- a/weaver/converter/cloudconvert/cloudconvert.go
+++ b/weaver/converter/cloudconvert/cloudconvert.go
@@ -190,7 +190,6 @@ func (c CloudConvert) Convert(s converter.ConversionSource, done <-chan struct{}
 	var b []byte
 
 	if s.IsLocal {
-		defer os.Remove(s.URI)
 		b, err := c.Client.QuickConversion(s.URI, c.AWSS3, "html", "pdf")
 		if err != nil {
 			return nil, err

--- a/weaver/handlers.go
+++ b/weaver/handlers.go
@@ -11,6 +11,7 @@ import (
 	"gopkg.in/alexcesaro/statsd.v2"
 	"log"
 	"net/http"
+	"os"
 	"runtime"
 )
 
@@ -40,6 +41,11 @@ func statsHandler(c *gin.Context) {
 }
 
 func conversionHandler(c *gin.Context, source converter.ConversionSource) {
+	// GC if converting temporary file
+	if source.IsLocal {
+		defer os.Remove(source.URI)
+	}
+
 	_, aggressive := c.GetQuery("aggressive")
 
 	conf := c.MustGet("config").(Config)


### PR DESCRIPTION
Both converters 'clean up' the temporary file after the
convert method returns. This results in the fallback
converter failing because the file no longer exists.

---

cc: @arachnys/qa 

I don't think this needs much QA. We just need to get it out quick once the tests passes.