### PR TITLE
Support for Hebrew characters

### DIFF
--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get -yq update && \
         ttf-liberation \
         ttf-unfonts-core \
         ttf-wqy-zenhei \
+        culmus \
     && apt-get -yq autoremove \
     && apt-get -yq clean \
     && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
Hebrew characters were being printed as boxes.

See https://s3-eu-west-1.amazonaws.com/athena-pdf-public/01985f77-0a15-4ff1-a5b6-3ab12c2b46f7.pdf