### PR TITLE
Add support for browser zoom

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -25,6 +25,7 @@ It can be used anywhere with [Docker][docker] installed, even in a headless envi
 - Adjustable PDF generation delay
 - Adjustable, built-in timeout mechanism
 - Adjustable cache control
+- Adjustable browser zoom settings
 - Automatically falls back to `screen` stylesheets if no `print` stylesheet is defined
 - [Aggressive mode](docs/aggressive.md): declutter web pages, and improves readability
 - Bypass paywalls for most digital publications with a single `-B` flag (experimental feature)

--- a/cli/src/athenapdf.js
+++ b/cli/src/athenapdf.js
@@ -25,6 +25,7 @@ athena
     .option("-T, --timeout <seconds>", "seconds before timing out (default: 120)", parseInt)
     .option("-D, --delay <milliseconds>", "milliseconds delay before saving (default: 200)", parseInt)
     .option("-P, --pagesize <size>", "page size of the generated PDF (default: A4)", /^(A3|A4|A5|Legal|Letter|Tabloid)$/i, "A4")
+    .option("-Z --zoom <factor>", "zoom factor for higher scale rendering (default: 1 - represents 100%)", parseInt)
     .option("-S, --stdout", "write conversion to stdout")
     .option("-A, --aggressive", "aggressive mode / runs dom-distiller")
     .option("-B, --bypass", "bypasses paywalls on digital publications (experimental feature)")
@@ -87,7 +88,8 @@ var bwOpts = {
     show: (athena.debug || false),
     webPreferences: {
         nodeIntegration: false,
-        webSecurity: false
+        webSecurity: false,
+        zoomFactor: (athena.zoom || 1)
     }
 };
 


### PR DESCRIPTION
Currently, the athena CLI does not support the BrowserWindow web preference for scale. This forced canvas elements to render fairly pixelated. This PR allows the passing in of a zoom option to set the zoom scale (e.g. 2 = 200%, 3 = 300%).

Here is a screenshot of a PDF rendered at zoom scale 1:

![test14_pdf__page_2_of_4_](https://cloud.githubusercontent.com/assets/12481/15124591/036f8e02-15e6-11e6-9eb2-b7af1be61492.png)

And here is a screenshot at zoom scale 3:

![test12_pdf__page_2_of_4_](https://cloud.githubusercontent.com/assets/12481/15124598/0a5d4614-15e6-11e6-9933-14cbb2ffd674.png)
