### PR TITLE
Upgrade to Electron 1.1.0

### DIFF
--- a/cli/Dockerfile.build
+++ b/cli/Dockerfile.build
@@ -11,7 +11,6 @@ ADD package.json /athenapdf/build/artifacts/
 RUN cp -r /athenapdf/node_modules/ /athenapdf/build/artifacts/
 
 ADD src /athenapdf/build/artifacts/
-RUN sed -i "1s/^/process.argv.unshift(\"--\");\n /" /athenapdf/build/artifacts/athenapdf.js
 RUN npm run build:linux
 
 CMD ["/bin/sh"]

--- a/cli/package.json
+++ b/cli/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "commander": "^2.9.0",
-    "electron-prebuilt": "^1.0.2",
+    "electron-prebuilt": "^1.1.0",
     "rw": "^1.3.2"
   },
   "devDependencies": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "athenapdf",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "A simple CLI tool to convert HTML to PDF from a local file or a URL to a web page using Electron (Chromium).",
   "keywords": "electron, chrome, cli, html, pdf, converter, generate",
   "homepage": "https://www.athenapdf.com/",
@@ -19,12 +19,12 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "rm -rf build/",
     "build:prepare": "mkdir -p build/ && cp -r src/ build/artifacts/ && cp package.json build/artifacts/ && cd build/artifacts/ && npm i --production",
-    "build:linux": "electron-packager build/artifacts/ athenapdf --platform=linux --arch=x64 --version=1.0.0 --out=build/ --overwrite --asar=true",
+    "build:linux": "electron-packager build/artifacts/ athenapdf --platform=linux --arch=x64 --version=1.1.0 --out=build/ --overwrite --asar=true",
     "build": "npm run clean && npm run build:prepare && npm run build:linux"
   },
   "dependencies": {
     "commander": "^2.9.0",
-    "electron-prebuilt": "^1.0.0",
+    "electron-prebuilt": "^1.0.2",
     "rw": "^1.3.2"
   },
   "devDependencies": {

--- a/cli/src/athenapdf.js
+++ b/cli/src/athenapdf.js
@@ -18,8 +18,12 @@ var ses = null;
 var uriArg = null;
 var outputArg = null;
 
+if (!process.defaultApp) {
+    process.argv.unshift("--");
+}
+
 athena
-    .version("2.2.0")
+    .version("2.3.0")
     .description("convert HTML to PDF via stdin or a local / remote URI")
     .option("--debug", "show GUI", false)
     .option("-T, --timeout <seconds>", "seconds before timing out (default: 120)", parseInt)


### PR DESCRIPTION
This commit brings athenapdf CLI to v2.3.0.

- Use `process.defaultApp` to process the command line arguments:
  `process.argv` is different in a built Electron app vs. a default
  app; this change allows us to remove the hack in the Docker build
  image
- Notable Electron changes: Chrome 50.0.2661.102, and Node.js 6.1.0