### PR TITLE
Added support for custom margins

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -26,6 +26,7 @@ It can be used anywhere with [Docker][docker] installed, even in a headless envi
 - Adjustable, built-in timeout mechanism
 - Adjustable cache control
 - Adjustable browser zoom settings
+- Adjustable margin sizes
 - Automatically falls back to `screen` stylesheets if no `print` stylesheet is defined
 - [Aggressive mode](docs/aggressive.md): declutter web pages, and improves readability
 - Bypass paywalls for most digital publications with a single `-B` flag (experimental feature)

--- a/cli/src/athenapdf.js
+++ b/cli/src/athenapdf.js
@@ -29,6 +29,7 @@ athena
     .option("-T, --timeout <seconds>", "seconds before timing out (default: 120)", parseInt)
     .option("-D, --delay <milliseconds>", "milliseconds delay before saving (default: 200)", parseInt)
     .option("-P, --pagesize <size>", "page size of the generated PDF (default: A4)", /^(A3|A4|A5|Legal|Letter|Tabloid)$/i, "A4")
+    .option("-M, --margin <marginType>", "margins to use when generating the PDF (default: standard)", /^(standard|minimal|none)$/i, "standard")
     .option("-Z --zoom <factor>", "zoom factor for higher scale rendering (default: 1 - represents 100%)", parseInt)
     .option("-S, --stdout", "write conversion to stdout")
     .option("-A, --aggressive", "aggressive mode / runs dom-distiller")
@@ -110,8 +111,16 @@ const loadOpts = {
     "extraHeaders": athena.cache ? "" : "pragma: no-cache\n"
 };
 
+// Enum for Electron's marginType codes
+var MarginEnum = {
+  "standard": 0,
+  "minimal": 1,
+  "none": 2,
+};
+
 const pdfOpts = {
     pageSize: athena.pagesize,
+    marginType: MarginEnum[athena.margin],
     printBackground: athena.background,
     landscape: !athena.portrait
 };

--- a/cli/src/athenapdf.js
+++ b/cli/src/athenapdf.js
@@ -112,7 +112,7 @@ const loadOpts = {
 };
 
 // Enum for Electron's marginType codes
-var MarginEnum = {
+const MarginEnum = {
   "standard": 0,
   "none": 1,
   "minimal": 2,

--- a/cli/src/athenapdf.js
+++ b/cli/src/athenapdf.js
@@ -29,7 +29,7 @@ athena
     .option("-T, --timeout <seconds>", "seconds before timing out (default: 120)", parseInt)
     .option("-D, --delay <milliseconds>", "milliseconds delay before saving (default: 200)", parseInt)
     .option("-P, --pagesize <size>", "page size of the generated PDF (default: A4)", /^(A3|A4|A5|Legal|Letter|Tabloid)$/i, "A4")
-    .option("-M, --margins <marginsType>", "margins to use when generating the PDF (default: standard)", /^(standard|minimal|none)$/i, "standard")
+    .option("-M, --margins <marginsType>", "margins to use when generating the PDF (default: standard)", /^(standard|none|minimal)$/i, "standard")
     .option("-Z --zoom <factor>", "zoom factor for higher scale rendering (default: 1 - represents 100%)", parseInt)
     .option("-S, --stdout", "write conversion to stdout")
     .option("-A, --aggressive", "aggressive mode / runs dom-distiller")
@@ -114,8 +114,8 @@ const loadOpts = {
 // Enum for Electron's marginType codes
 var MarginEnum = {
   "standard": 0,
-  "minimal": 1,
-  "none": 2,
+  "none": 1,
+  "minimal": 2,
 };
 
 const pdfOpts = {

--- a/cli/src/athenapdf.js
+++ b/cli/src/athenapdf.js
@@ -29,7 +29,7 @@ athena
     .option("-T, --timeout <seconds>", "seconds before timing out (default: 120)", parseInt)
     .option("-D, --delay <milliseconds>", "milliseconds delay before saving (default: 200)", parseInt)
     .option("-P, --pagesize <size>", "page size of the generated PDF (default: A4)", /^(A3|A4|A5|Legal|Letter|Tabloid)$/i, "A4")
-    .option("-M, --margin <marginType>", "margins to use when generating the PDF (default: standard)", /^(standard|minimal|none)$/i, "standard")
+    .option("-M, --margins <marginsType>", "margins to use when generating the PDF (default: standard)", /^(standard|minimal|none)$/i, "standard")
     .option("-Z --zoom <factor>", "zoom factor for higher scale rendering (default: 1 - represents 100%)", parseInt)
     .option("-S, --stdout", "write conversion to stdout")
     .option("-A, --aggressive", "aggressive mode / runs dom-distiller")
@@ -120,7 +120,7 @@ var MarginEnum = {
 
 const pdfOpts = {
     pageSize: athena.pagesize,
-    marginType: MarginEnum[athena.margin],
+    marginsType: MarginEnum[athena.margins],
     printBackground: athena.background,
     landscape: !athena.portrait
 };


### PR DESCRIPTION
The `marginsType` option (from [Electron's printToPDF spec](http://electron.atom.io/docs/api/web-contents/#webcontentsprinttopdfoptions-callback)) was strangely missing, so I added it in now as a CLI argument with the following options:

- standard (0)
- none (1)
- minimal (2)