### PR TITLE
Fix minor bug in `screen` media hack

### DIFF
--- a/cli/src/plugin_media.js
+++ b/cli/src/plugin_media.js
@@ -1,5 +1,5 @@
-var print = document.querySelectorAll('[type="text/css"][media*="print"]');
-var screen = document.querySelectorAll('[type="text/css"][media*="screen"]');
+var print = document.querySelectorAll('[rel="stylesheet"][media*="print"]');
+var screen = document.querySelectorAll('[rel="stylesheet"][media*="screen"]');
 
 if (print.length === 0) {
     for (var i = 0, l = screen.length; i < l; i++) {


### PR DESCRIPTION
Some websites define a `media` type for their CSS links.
However, there are times when this is counterintuitive as it makes
the printed version of the page look bad. This hack attempts to
solve the problem by removing the media attribute; it makes 'most'
websites look a lot better.

It currently works by searching for 'text/css' in the link type.
However, this attribute is optional, and defaults to 'text/css',
so quite a few sites do not define this.

This fix looks for `rel=stylesheet` instead as this is an attribute
that MUST be set.