### PR TITLE
Add support for custom file extensions in a local conversion strategy

### DIFF
--- a/weaver/converter/source.go
+++ b/weaver/converter/source.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/cookiejar"
+	"os"
 	"path/filepath"
 )
 
@@ -140,12 +141,23 @@ func uriSource(s *ConversionSource, uri string) error {
 	return nil
 }
 
+func setCustomExtension(s *ConversionSource, ext string) error {
+	if s.IsLocal && len(ext) > 0 {
+		newPath := s.URI + "." + ext
+		if err := os.Rename(s.URI, newPath); err != nil {
+			return err
+		}
+		s.URI = newPath
+	}
+	return nil
+}
+
 // NewConversionSource creates, and returns a new ConversionSource.
 // It accepts either a URI to a remote resource or a reader containing a stream
 // of bytes. If both parameters are specified, the reader takes precedence.
 // The ConversionSource is prepared using one of two strategies: a local
 // conversion (see rawSource) or a remote conversion (see uriSource).
-func NewConversionSource(uri string, body io.Reader) (*ConversionSource, error) {
+func NewConversionSource(uri string, body io.Reader, ext string) (*ConversionSource, error) {
 	s := new(ConversionSource)
 
 	var err error
@@ -156,6 +168,10 @@ func NewConversionSource(uri string, body io.Reader) (*ConversionSource, error) 
 	}
 
 	if err != nil {
+		return nil, err
+	}
+
+	if err := setCustomExtension(s, ext); err != nil {
 		return nil, err
 	}
 

--- a/weaver/handlers.go
+++ b/weaver/handlers.go
@@ -140,7 +140,9 @@ func convertByURLHandler(c *gin.Context) {
 		return
 	}
 
-	source, err := converter.NewConversionSource(url, nil)
+	ext := c.Query("ext")
+
+	source, err := converter.NewConversionSource(url, nil, ext)
 	if err != nil {
 		s.Increment("conversion_error")
 		if ravenOk {
@@ -164,7 +166,9 @@ func convertByFileHandler(c *gin.Context) {
 		return
 	}
 
-	source, err := converter.NewConversionSource("", file)
+	ext := c.Query("ext")
+
+	source, err := converter.NewConversionSource("", file, ext)
 	if err != nil {
 		s.Increment("conversion_error")
 		if ravenOk {


### PR DESCRIPTION
Previously, local conversions (i.e. save, and load a conversion
file through `/tmp`) are 'extensionless'.

This works fine for majority of use-cases (HTML to PDF).
However, Chromium provides support for loading MHTML files
(message/rfc822) as long as the extension of the file ends with
`.mhtml`, otherwise it will attempt to download the file or
otherwise load it without the necessary formatting.

This commit allows custom file extensions to be specified using
the `ext` parameter (e.g. `?ext=mhtml`).

Alternatively, we could infer the type of the file through a type
hint provided by the request or from the contents of the file.
But, this will add MHTML specific logic that will pollute the
source code, and deviate the project from its original goal of
converting HTML to PDF. The solution described above allows for
more generic additions in the future.

---

cc: @arachnys/qa 