### PR TITLE
Returning failure on 4XX and 5XX HTTP response codes

### DIFF
--- a/cli/src/athenapdf.js
+++ b/cli/src/athenapdf.js
@@ -191,6 +191,15 @@ app.on("ready", () => {
         }
     });
 
+    bw.webContents.on("did-get-response-details", (e, status, newURL, originalURL, httpResponseCode, requestMethod, referrer, headers, resourceType) => {
+        if (httpResponseCode >= 400) {
+            console.error(`Failed to load ${newURL} - got HTTP code ${httpResponseCode}`);
+            if (originalURL === uriArg) {
+                app.exit(1);
+            }
+        }
+    });
+
     bw.webContents.on("crashed", () => {
         console.error(`The renderer process has crashed.`);
         app.exit(1);

--- a/cli/src/athenapdf.js
+++ b/cli/src/athenapdf.js
@@ -194,7 +194,7 @@ app.on("ready", () => {
     bw.webContents.on("did-get-response-details", (e, status, newURL, originalURL, httpResponseCode, requestMethod, referrer, headers, resourceType) => {
         if (httpResponseCode >= 400) {
             console.error(`Failed to load ${newURL} - got HTTP code ${httpResponseCode}`);
-            if (originalURL === uriArg) {
+            if (resourceType === 'mainFrame') {
                 app.exit(1);
             }
         }


### PR DESCRIPTION
This PR adds some rudimentary error handling when converting a URL into a PDF. If the URL returns HTTP code >= 400, it is now considered an error.

The CLI version will exit with status 1 in this case, and the microservice will return 500 Internal server error.