### PR TITLE
Upgrade to Electron 1.2.3

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "athenapdf",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "A simple CLI tool to convert HTML to PDF from a local file or a URL to a web page using Electron (Chromium).",
   "keywords": "electron, chrome, cli, html, pdf, converter, generate",
   "homepage": "https://www.athenapdf.com/",
@@ -19,15 +19,15 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "rm -rf build/",
     "build:prepare": "mkdir -p build/ && cp -r src/ build/artifacts/ && cp package.json build/artifacts/ && cd build/artifacts/ && npm i --production",
-    "build:linux": "electron-packager build/artifacts/ athenapdf --platform=linux --arch=x64 --version=1.2.0 --out=build/ --overwrite --asar=true",
+    "build:linux": "electron-packager build/artifacts/ athenapdf --platform=linux --arch=x64 --version=1.2.3 --out=build/ --overwrite --asar=true",
     "build": "npm run clean && npm run build:prepare && npm run build:linux"
   },
   "dependencies": {
     "commander": "^2.9.0",
-    "electron-prebuilt": "1.2.0",
+    "electron-prebuilt": "1.2.3",
     "rw": "^1.3.2"
   },
   "devDependencies": {
-    "electron-packager": "^7.0.1"
+    "electron-packager": "^7.0.4"
   }
 }

--- a/cli/src/athenapdf.js
+++ b/cli/src/athenapdf.js
@@ -23,7 +23,7 @@ if (!process.defaultApp) {
 }
 
 athena
-    .version("2.4.0")
+    .version("2.5.0")
     .description("convert HTML to PDF via stdin or a local / remote URI")
     .option("--debug", "show GUI", false)
     .option("-T, --timeout <seconds>", "seconds before timing out (default: 120)", parseInt)


### PR DESCRIPTION
The current version of `athenapdf` CLI has been tagged `2.4.0` on Docker Hub. If this release proves problematic (which it should not), ensure you are locked-in on version `2.4.0`.

---

Notable changes includes:

- Update to Chrome 51.0.2704.84 (security patches)
- Fix for `executeJavaScript` when used with `webSecurity: false`:
  this should resolve problems with plugins not being executed

More information: https://github.com/electron/electron/releases/tag/v1.2.3