### PR TITLE
Update Dockerfile to remove redundant layers

### DIFF
--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -35,12 +35,12 @@ RUN apt-get -yq update && \
     && rm -rf /var/lib/apt/lists/* \
     && truncate -s 0 /var/log/*log
 
-ADD build/athenapdf-linux-x64/ /athenapdf/
+COPY build/athenapdf-linux-x64/ /athenapdf/
 WORKDIR /athenapdf/
 
 ENV PATH /athenapdf/:$PATH
 
-ADD entrypoint.sh /athenapdf/entrypoint.sh
+COPY entrypoint.sh /athenapdf/entrypoint.sh
 
 RUN mkdir -p /converted/
 WORKDIR /converted/

--- a/cli/Dockerfile.build
+++ b/cli/Dockerfile.build
@@ -1,16 +1,16 @@
-FROM mhart/alpine-node:5.9.1
+FROM mhart/alpine-node:6
 MAINTAINER Arachnys <techteam@arachnys.com>
 
 RUN mkdir -p /athenapdf/build/artifacts/
 WORKDIR /athenapdf/
 
-ADD package.json /athenapdf/
+COPY package.json /athenapdf/
 RUN npm install
 
-ADD package.json /athenapdf/build/artifacts/
+COPY package.json /athenapdf/build/artifacts/
 RUN cp -r /athenapdf/node_modules/ /athenapdf/build/artifacts/
 
-ADD src /athenapdf/build/artifacts/
+COPY src /athenapdf/build/artifacts/
 RUN npm run build:linux
 
 CMD ["/bin/sh"]

--- a/weaver/Dockerfile
+++ b/weaver/Dockerfile
@@ -7,15 +7,14 @@ RUN \
   wget https://github.com/Yelp/dumb-init/releases/download/v1.0.0/dumb-init_1.0.0_amd64.deb \
   && dpkg -i dumb-init_*.deb \
   && rm dumb-init_*.deb \
-  ;
+  && mkdir -p /athenapdf-service/tmp/
 
-RUN mkdir -p /athenapdf-service/tmp/
-ADD build/weaver /athenapdf-service/
+COPY build/weaver /athenapdf-service/
 WORKDIR /athenapdf-service/
 
 ENV PATH /athenapdf-service/:$PATH
 
-ADD conf/ /athenapdf-service/conf/
+COPY conf/ /athenapdf-service/conf/
 
 EXPOSE 8080
 

--- a/weaver/Dockerfile.build
+++ b/weaver/Dockerfile.build
@@ -6,8 +6,9 @@ RUN apk add --update git
 COPY . /go/src/github.com/arachnys/athenapdf/weaver
 WORKDIR /go/src/github.com/arachnys/athenapdf/weaver
 
-RUN go get -v -d
-RUN go install -v
-RUN CGO_ENABLED=0 go build -ldflags "-s" -a -installsuffix cgo -o weaver .
+RUN \
+  go get -v -d \
+  && go install -v \
+  && CGO_ENABLED=0 go build -ldflags "-s" -a -installsuffix cgo -o weaver .
 
 CMD ["/bin/sh"]


### PR DESCRIPTION
Also, upgraded the Node version used for building the CLI.

---

This will probably cause all sorts of cache invalidation. Also, we should probably be using a fixed version (`FROM arachnysdocker/athenapdf`).