### PR TITLE
new handler proposal: convert string by POST

### DIFF
--- a/weaver/handlers.go
+++ b/weaver/handlers.go
@@ -191,10 +191,9 @@ func convertByStringHandler(c *gin.Context) {
 	r, ravenOk := c.Get("sentry")
 
 	content, ok := c.GetPostForm("content")
-	log.Printf("[Converting with content] %s", content)
 	if !ok {
 		c.AbortWithError(http.StatusBadRequest, ErrFileInvalid).SetType(gin.ErrorTypePublic)
-		s.Increment("invalid_file")
+		s.Increment("invalid_content")
 		return
 	}
 

--- a/weaver/main.go
+++ b/weaver/main.go
@@ -62,6 +62,7 @@ func InitSecureRoutes(router *gin.Engine, conf Config) {
 	authorized.Use(AuthorizationMiddleware(conf.AuthKey))
 	authorized.GET("/convert", convertByURLHandler)
 	authorized.POST("/convert", convertByFileHandler)
+	authorized.POST("/convert-str", convertByStringHandler)
 }
 
 // InitSimpleRoutes creates non-essential routes for monitoring and/or


### PR DESCRIPTION
I have an use case where I can't give AthenaPDF a file or a url. In this case it's really useful to support PDF creation from an HTML string given by POST in the request body.

The new handler works like this:

```
$ curl http://<dockerurl>:8080/convert-str?auth=arachnys-weaver -H "Content-Type: application/x-www-form-urlencoded" -d "content=%3Cdiv%3Esom+content%3C%2Fdiv%3E"
```

Hope this is as useful for others as it is for me!