### PR TITLE
Fix `media` plugin / hack for style elements

### DIFF
--- a/cli/src/athenapdf.js
+++ b/cli/src/athenapdf.js
@@ -194,7 +194,7 @@ app.on("ready", () => {
     bw.webContents.on("did-get-response-details", (e, status, newURL, originalURL, httpResponseCode, requestMethod, referrer, headers, resourceType) => {
         if (httpResponseCode >= 400) {
             console.error(`Failed to load ${newURL} - got HTTP code ${httpResponseCode}`);
-            if (resourceType === 'mainFrame') {
+            if (resourceType === "mainFrame") {
                 app.exit(1);
             }
         }

--- a/cli/src/plugin_media.js
+++ b/cli/src/plugin_media.js
@@ -1,5 +1,5 @@
-var print = document.querySelectorAll('[rel="stylesheet"][media*="print"]');
-var screen = document.querySelectorAll('[rel="stylesheet"][media*="screen"]');
+var print = document.querySelectorAll("[rel='stylesheet'][media*='print'], style[media*='print']");
+var screen = document.querySelectorAll("[rel='stylesheet'][media*='screen'], style[media*='screen']");
 
 if (print.length === 0) {
     for (var i = 0, l = screen.length; i < l; i++) {


### PR DESCRIPTION
The `media` attribute is automatically removed for stylesheet
links if there are no print styles defined.

Previously however, the aforementioned 'autoremoving' behaviour
only applied to elements with `rel=stylesheet`, and it did not
apply to `style` elements.

This commit addresses the problem by including `style` elements
in the query selector.

---

Fixes #61 (Github)

Signed-off-by: Ian Lai <ian@fyianlai.com>