### PR TITLE
fixes dependency hence electron-prebuilt has been renamed to electron

### DIFF
--- a/cli/bin/athenapdf
+++ b/cli/bin/athenapdf
@@ -2,7 +2,7 @@
 
 const path = require("path");
 const spawn = require("child_process").spawn;
-const electron = require("electron-prebuilt");
+const electron = require("electron");
 
 var args = process.argv.slice(2);
 var src = path.resolve(path.join(__dirname, "/../src/athenapdf.js"));

--- a/cli/package.json
+++ b/cli/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "commander": "^2.9.0",
-    "electron-prebuilt": "1.4.0",
+    "electron": "1.4.0",
     "rw": "^1.3.2"
   },
   "devDependencies": {


### PR DESCRIPTION
fixes npm complaining about the following issue. same electron version has been preserved.

`npm WARN deprecated electron-prebuilt@1.4.0: electron-prebuilt has been renamed to electron. For more details, see http://electron.atom.io/blog/2016/08/16/npm-install-electron`