### PR TITLE
WebGL support inside Docker

### DIFF
--- a/cli/src/athenapdf.js
+++ b/cli/src/athenapdf.js
@@ -22,6 +22,8 @@ if (!process.defaultApp) {
     process.argv.unshift("--");
 }
 
+app.commandLine.appendSwitch('ignore-gpu-blacklist', 'true');
+
 athena
     .version("2.8.0")
     .description("convert HTML to PDF via stdin or a local / remote URI")
@@ -60,7 +62,7 @@ if (uriArg === "-") {
     let base64Html = new Buffer(rw.readFileSync("/dev/stdin", "utf8"), "utf8").toString("base64");
     uriArg = "data:text/html;base64," + base64Html;
 // Handle local paths
-} else if (uriArg.toLowerCase().indexOf("http") !== 0) {
+} else if (uriArg.toLowerCase().startsWith("http") || uriArg.toLowerCase().startsWith("chrome://")) {
     uriArg = url.format({
         protocol: "file",
         pathname: path.resolve(uriArg),

--- a/cli/src/athenapdf.js
+++ b/cli/src/athenapdf.js
@@ -62,7 +62,7 @@ if (uriArg === "-") {
     let base64Html = new Buffer(rw.readFileSync("/dev/stdin", "utf8"), "utf8").toString("base64");
     uriArg = "data:text/html;base64," + base64Html;
 // Handle local paths
-} else if (uriArg.toLowerCase().startsWith("http") || uriArg.toLowerCase().startsWith("chrome://")) {
+} else if (!uriArg.toLowerCase().startsWith("http") && !uriArg.toLowerCase().startsWith("chrome://")) {
     uriArg = url.format({
         protocol: "file",
         pathname: path.resolve(uriArg),

--- a/cli/src/athenapdf.js
+++ b/cli/src/athenapdf.js
@@ -22,8 +22,6 @@ if (!process.defaultApp) {
     process.argv.unshift("--");
 }
 
-app.commandLine.appendSwitch('ignore-gpu-blacklist', 'true');
-
 athena
     .version("2.8.0")
     .description("convert HTML to PDF via stdin or a local / remote URI")
@@ -40,6 +38,7 @@ athena
     .option("--no-portrait", "render in landscape")
     .option("--no-background", "omit CSS backgrounds")
     .option("--no-cache", "disables caching")
+    .option("--ignore-gpu-blacklist", "Enables GPU in Docker environment")
     .arguments("<URI> [output]")
     .action((uri, output) => {
         uriArg = uri;
@@ -91,6 +90,8 @@ if (athena.proxy) {
     }
     app.commandLine.appendSwitch("proxy-server", athena.proxy);
 }
+
+app.commandLine.appendSwitch('ignore-gpu-blacklist', athena.ignoreGpuBlacklist || "false");
 
 // Preferences
 var bwOpts = {


### PR DESCRIPTION
This makes sites with WebGL canvases render correctly inside docker (my machine has docker for mac). 

This PR also allows you to produce a pdf of `chrome://gpu` (which helps debug WebGL). 

The ignore-gpu-blacklist line might want to be set conditionally either with a flag? Or if we can detect we're inside Docker?

