### PR TITLE
Add option for Custom Request Headers

### DIFF
--- a/cli/src/athenapdf.js
+++ b/cli/src/athenapdf.js
@@ -127,7 +127,7 @@ if (process.platform === "linux") {
 var extraHeaders = athena.httpHeader;
 
 // Toggle cache headers
-if (athena.cache) {
+if (!athena.cache) {
     extraHeaders.push("pragma: no-cache");
 }
 const loadOpts = {

--- a/cli/src/athenapdf.js
+++ b/cli/src/athenapdf.js
@@ -22,9 +22,10 @@ if (!process.defaultApp) {
     process.argv.unshift("--");
 }
 
-function collect(val, memo){
-    memo.push(val);
-    return memo;
+const headersDict = (keyVal, dict) => {
+    const [key, ...values] = keyVal.split(":");
+    dict[key] = values.join(":");
+    return dict;
 }
 
 athena
@@ -39,7 +40,7 @@ athena
     .option("-S, --stdout", "write conversion to stdout")
     .option("-A, --aggressive", "aggressive mode / runs dom-distiller")
     .option("-B, --bypass", "bypasses paywalls on digital publications (experimental feature)")
-    .option("-R, --request-header <key-value pair>", "Request header to send in the format 'key=value'. Both 'key' and 'value' are expected to be urlencoded", collect, [])
+    .option("-H, --http-header <key:value>", "add custom headers to request", headersDict, {})
     .option("--proxy <url>", "use proxy to load remote HTML")
     .option("--no-portrait", "render in landscape")
     .option("--no-background", "omit CSS backgrounds")
@@ -177,20 +178,10 @@ app.on("ready", () => {
 
     ses = bw.webContents.session;
 
-    // When the --request-header is set, add request headers
-    if (athena.requestHeader && athena.requestHeader !== []) {
-        var headers = athena.requestHeader.reduce((arr, val) => {
-            var hold = val.split("=");
-
-            if (hold.length === 2) {
-                arr[hold[0]] = hold[1];
-            }
-
-            return arr;
-
-        }, {});
+    // When the --http-header is set, add request headers
+    if (Object.keys(athena.httpHeader).length) {
         ses.webRequest.onBeforeSendHeaders((details, callback) => {
-            callback({cancel: false, requestHeaders: headers});
+            callback({cancel: false, requestHeaders: athena.httpHeader});
         });
     }
 

--- a/cli/src/athenapdf.js
+++ b/cli/src/athenapdf.js
@@ -131,7 +131,7 @@ if (athena.cache) {
     extraHeaders.push("pragma: no-cache");
 }
 const loadOpts = {
-    "extraHeaders": extraHeaders.join("\n");
+    "extraHeaders": extraHeaders.join("\n")
 };
 
 // Enum for Electron's marginType codes

--- a/cli/src/athenapdf.js
+++ b/cli/src/athenapdf.js
@@ -22,7 +22,7 @@ if (!process.defaultApp) {
     process.argv.unshift("--");
 }
 
-const headersDict = (header, arr) => {
+const addHeader = (header, arr) => {
     arr.push(header);
     return arr;
 }
@@ -39,7 +39,7 @@ athena
     .option("-S, --stdout", "write conversion to stdout")
     .option("-A, --aggressive", "aggressive mode / runs dom-distiller")
     .option("-B, --bypass", "bypasses paywalls on digital publications (experimental feature)")
-    .option("-H, --http-header <key:value>", "add custom headers to request", headersDict, [])
+    .option("-H, --http-header <key:value>", "add custom headers to request", addHeader, [])
     .option("--proxy <url>", "use proxy to load remote HTML")
     .option("--no-portrait", "render in landscape")
     .option("--no-background", "omit CSS backgrounds")
@@ -123,9 +123,15 @@ if (process.platform === "linux") {
     };
 }
 
-// Toggle cache headers and add custom headers is specified
+// Add custom headers if specified
+var extraHeaders = athena.httpHeader;
+
+// Toggle cache headers
+if (athena.cache) {
+    extraHeaders.push("pragma: no-cache");
+}
 const loadOpts = {
-    "extraHeaders": (athena.cache ? "" : "pragma: no-cache\n") + athena.httpHeader.join("\n")
+    "extraHeaders": extraHeaders.join("\n");
 };
 
 // Enum for Electron's marginType codes


### PR DESCRIPTION
cURL style header implementation
    `<command> -H header_key:header_value -H header_key_1:header_value ...`
or
    `<command> --http-header key:value --http-header key:value ...`

----
A Different approach to PR #72   - coded before realizing it existed. 