### PR TITLE
upload conversion support for aws s3 chain credentials and custom s3 acl

### DIFF
--- a/weaver/handlers.go
+++ b/weaver/handlers.go
@@ -61,6 +61,7 @@ func conversionHandler(c *gin.Context, source converter.ConversionSource) {
 		c.Query("aws_secret"),
 		c.Query("s3_bucket"),
 		c.Query("s3_key"),
+		c.Query("s3_acl"),
 	}
 
 	var conversion converter.Converter


### PR DESCRIPTION
- made upload conversion processing use chain credentials if static credentials are not provided
- allow caller to pass s3_acl instead of always using public-read acl