### PR TITLE
[WIP] Build with habitat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules
 .DS_STORE
 *.env
 !sample.env
+results/

--- a/cli/habitat/plan.sh
+++ b/cli/habitat/plan.sh
@@ -1,0 +1,66 @@
+pkg_name=athenapdf-cli
+pkg_origin=jarvus
+pkg_version=2.10.0
+pkg_bin_dirs=(bin)
+pkg_lib_dirs=(lib)
+
+pkg_deps=(
+  core/glibc
+  core/gcc-libs
+  core/coreutils
+  core/node
+
+  core/freetype
+  core/fontconfig
+  core/dbus
+  core/expat
+  core/cairo
+  core/pango
+  core/nss
+  core/nspr
+  core/glib
+  xorg/xlib
+  xorg/libxrender
+  xorg/libxext
+  xorg/libxcb
+)
+pkg_build_deps=(
+  core/patchelf
+)
+
+do_unpack() {
+  pushd "${CACHE_PATH}" > /dev/null
+
+  cp -vr "${PLAN_CONTEXT}/../src" .
+  cp -v "${PLAN_CONTEXT}/../package.json" .
+
+  popd > /dev/null
+
+  return 0
+}
+
+do_build() {
+  pushd "${CACHE_PATH}" > /dev/null
+
+  npm install
+  fix_interpreter "node_modules/.bin/*" core/coreutils bin/env
+  node_modules/.bin/electron-packager . athenapdf --platform=linux --arch=x64 --version=1.7.5
+  patchelf --interpreter "$(pkg_path_for glibc)/lib/ld-linux-x86-64.so.2" --set-rpath "${LD_RUN_PATH}" athenapdf-linux-x64/athenapdf
+
+  find athenapdf-linux-x64 -name "*.so" \
+    -exec patchelf --set-rpath "${LD_RUN_PATH}" {} \;
+
+  popd > /dev/null
+}
+
+do_install() {
+  pushd "${pkg_prefix}" > /dev/null
+
+  cp -v "${CACHE_PATH}/athenapdf-linux-x64"/*.so lib/
+  cp -v "${CACHE_PATH}/athenapdf-linux-x64/athenapdf" bin/
+
+  ldd bin/*
+  attach
+
+  popd > /dev/null
+}


### PR DESCRIPTION
[Habitat](http://habitat.sh) can provide a way to run athenapdf with the same environmental consistency as docker, but with a much smaller distribution footprint and the ability to run it on metal or in a container. Habitat can even export a minimal docker container.

Current limitation is some gnome and X11 packages not being available in the habitat depot yet, I'm working through them gradually
- [X] libIDL (in [JarvusInnovations/habitat-plans#master](https://github.com/JarvusInnovations/habitat-plans))
- [X] dbus-glib (in [JarvusInnovations/habitat-plans#master](https://github.com/JarvusInnovations/habitat-plans))
- [ ] ORBit2 (started in [JarvusInnovations/habitat-plans#gconf2](https://github.com/JarvusInnovations/habitat-plans/tree/gconf2))
- [ ] gconf2 (started in [JarvusInnovations/habitat-plans#gconf2](https://github.com/JarvusInnovations/habitat-plans/tree/gconf2))
- [ ] libgtk-x11
- [ ] libdk-x11
- [ ] libatk
- [ ] libgdk_pixbuf
- [ ] libXi
- [ ] libXcursor
- [ ] libXdamage
- [ ] libXrandr
- [ ] libXcomposite
- [ ] libXfixes
- [ ] libXtst
- [ ] libXss
- [ ] libasound
- [ ] libcups