### PR TITLE
Add timeout to CloudConvert job based on the worker timeout

### DIFF
--- a/weaver/converter/cloudconvert/cloudconvert.go
+++ b/weaver/converter/cloudconvert/cloudconvert.go
@@ -25,6 +25,7 @@ type CloudConvert struct {
 type Client struct {
 	BaseURL string
 	APIKey  string
+	Timeout string
 }
 
 type Process struct {
@@ -67,6 +68,11 @@ func (c Client) QuickConversion(path string, awsS3 converter.AWSS3, inputFormat 
 	b := new(bytes.Buffer)
 	bw := multipart.NewWriter(b)
 
+	// Default timeout: 5 minutes
+	if c.Timeout == "" {
+		c.Timeout = "300"
+	}
+
 	// Use a map so we can easily extend the parameters (options)
 	params := map[string]string{
 		"apikey":       c.APIKey,
@@ -75,6 +81,7 @@ func (c Client) QuickConversion(path string, awsS3 converter.AWSS3, inputFormat 
 		"filename":     "tmp.html",
 		"inputformat":  inputFormat,
 		"outputformat": outputFormat,
+		"timeout":      c.Timeout,
 	}
 
 	part, err := bw.CreateFormFile("file", filepath.Base(path))

--- a/weaver/converter/cloudconvert/cloudconvert.go
+++ b/weaver/converter/cloudconvert/cloudconvert.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 type CloudConvert struct {
@@ -25,7 +26,7 @@ type CloudConvert struct {
 type Client struct {
 	BaseURL string
 	APIKey  string
-	Timeout string
+	Timeout time.Duration
 }
 
 type Process struct {
@@ -69,8 +70,8 @@ func (c Client) QuickConversion(path string, awsS3 converter.AWSS3, inputFormat 
 	bw := multipart.NewWriter(b)
 
 	// Default timeout: 5 minutes
-	if c.Timeout == "" {
-		c.Timeout = "300"
+	if c.Timeout == 0 {
+		c.Timeout = time.Minute * 5
 	}
 
 	// Use a map so we can easily extend the parameters (options)
@@ -81,7 +82,7 @@ func (c Client) QuickConversion(path string, awsS3 converter.AWSS3, inputFormat 
 		"filename":     "tmp.html",
 		"inputformat":  inputFormat,
 		"outputformat": outputFormat,
-		"timeout":      c.Timeout,
+		"timeout":      fmt.Sprintf("%.0f", c.Timeout.Seconds()),
 	}
 
 	part, err := bw.CreateFormFile("file", filepath.Base(path))

--- a/weaver/converter/cloudconvert/cloudconvert.go
+++ b/weaver/converter/cloudconvert/cloudconvert.go
@@ -56,6 +56,7 @@ type Conversion struct {
 	OutputFormat string `json:"outputformat"`
 	Wait         bool   `json:"wait"`
 	Download     string `json:"download,omitempty"`
+	Timeout      string `json:"timeout,omitempty"`
 	*Output      `json:"output,omitempty"`
 }
 
@@ -216,6 +217,7 @@ func (c CloudConvert) Convert(s converter.ConversionSource, done <-chan struct{}
 		Filename:     c.AWSS3.S3Key + ".html",
 		OutputFormat: "pdf",
 		Wait:         true,
+		Timeout:      fmt.Sprintf("%.0f", c.Timeout.Seconds()),
 	}
 
 	u := uuid.NewV4()

--- a/weaver/converter/cloudconvert/cloudconvert_test.go
+++ b/weaver/converter/cloudconvert/cloudconvert_test.go
@@ -28,7 +28,7 @@ func TestNewProcess(t *testing.T) {
 	c := Client{
 		ts.URL,
 		"test cloudconvert key",
-		"",
+		0,
 	}
 	process, err := c.NewProcess("html", "pdf")
 	if err != nil {

--- a/weaver/converter/cloudconvert/cloudconvert_test.go
+++ b/weaver/converter/cloudconvert/cloudconvert_test.go
@@ -25,7 +25,11 @@ func TestNewProcess(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	c := Client{ts.URL, "test cloudconvert key"}
+	c := Client{
+		ts.URL,
+		"test cloudconvert key",
+		"",
+	}
 	process, err := c.NewProcess("html", "pdf")
 	if err != nil {
 		t.Fatalf("newprocess returned an unexpected error: %+v", err)

--- a/weaver/handlers.go
+++ b/weaver/handlers.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"os"
 	"runtime"
+	"time"
 )
 
 var (
@@ -77,7 +78,7 @@ StartConversion:
 		cc := cloudconvert.Client{
 			conf.CloudConvert.APIUrl,
 			conf.CloudConvert.APIKey,
-			string(conf.WorkerTimeout + 5),
+			time.Second * time.Duration(conf.WorkerTimeout+5),
 		}
 		conversion = cloudconvert.CloudConvert{uploadConversion, cc}
 	}

--- a/weaver/handlers.go
+++ b/weaver/handlers.go
@@ -74,7 +74,11 @@ func conversionHandler(c *gin.Context, source converter.ConversionSource) {
 StartConversion:
 	conversion = athenapdf.AthenaPDF{uploadConversion, conf.AthenaCMD, aggressive}
 	if attempts != 0 {
-		cc := cloudconvert.Client{conf.CloudConvert.APIUrl, conf.CloudConvert.APIKey}
+		cc := cloudconvert.Client{
+			conf.CloudConvert.APIUrl,
+			conf.CloudConvert.APIKey,
+			string(conf.WorkerTimeout + 5),
+		}
 		conversion = cloudconvert.CloudConvert{uploadConversion, cc}
 	}
 	work = converter.NewWork(wq, conversion, source)


### PR DESCRIPTION
`5` is an arbitrary number to reduce the likelihood of overlap.

It does not seem like the underlying job is cancelled when the
request is closed. Furthermore, the default timeout for pro
accounts is very high (5 hours). It is better if we timeout quickly
for documents that are large, and likely to fail.