### PR TITLE
Fixed bug where the window-status plugin would not work if a user did…

### DIFF
--- a/pkg/runner/plugin/js/window-status.js
+++ b/pkg/runner/plugin/js/window-status.js
@@ -9,7 +9,7 @@ var waitForWindowStatus = function(desiredStatus) {
     });
 };
 
-if (typeof WINDOW_STATUS !== "undefined") {
+if (typeof WINDOW_STATUS === "undefined") {
     var WINDOW_STATUS = "ready";
 }
 


### PR DESCRIPTION
Fixed bug where the window-status plugin would not work if a user did not explicitly set the WINDOW_STATUS optional variable.