### PR TITLE
Add cookie headers to session

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -25,7 +25,8 @@
   "dependencies": {
     "commander": "^2.9.0",
     "electron": "2.0.4",
-    "rw": "^1.3.2"
+    "rw": "^1.3.2",
+    "set-cookie-parser": "^2.2.1"
   },
   "devDependencies": {
     "electron-packager": "^7.0.4"

--- a/cli/src/athenapdf.js
+++ b/cli/src/athenapdf.js
@@ -7,6 +7,7 @@ const rw = require("rw");
 const url = require("url");
 
 const athena = require("commander");
+const setCookie = require("set-cookie-parser");
 const electron = require("electron");
 const app = electron.app;
 const BrowserWindow = electron.BrowserWindow;
@@ -208,6 +209,21 @@ app.on("ready", () => {
         console.error(`Unable to convert an octet-stream, use stdin.`);
         app.exit(1);
     });
+
+    const cookieHeaders = athena.httpHeader
+        .filter(header => header.includes("Cookie:"))
+        .map(header =>
+             header.substring(header.indexOf("Cookie:") + "Cookie:".length).trim()
+        );
+    if (cookieHeaders) {
+        setCookie.parse(cookieHeaders, { decodeValues: false }).forEach(cookie => {
+            ses.cookies.set(Object.assign(cookie, { url: uriArg }), error => {
+                if (error) {
+                    console.error(error);
+                }
+            });
+        });
+    }
 
     bw.webContents.on("did-fail-load", (e, code, desc, url, isMainFrame) => {
         if (parseInt(code, 10) >= -3) return;


### PR DESCRIPTION
Setting cookie headers at the command line are not persisted if the page makes additional ajax requests.