### PR TITLE
Pass headers via weaver and store cookies in electron

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -2,7 +2,15 @@
   "name": "athenapdf",
   "version": "2.13.0",
   "description": "A simple CLI tool to convert HTML to PDF from a local file or a URL to a web page using Electron (Chromium).",
-  "keywords": "electron, chrome, cli, html, pdf, converter, generate",
+  "keywords": [
+    "electron",
+    "chrome",
+    "cli",
+    "html",
+    "pdf",
+    "converter",
+    "generate"
+  ],
   "homepage": "https://www.athenapdf.com/",
   "bugs": {
     "url": "https://github.com/arachnys/athenapdf/issues"
@@ -24,8 +32,9 @@
   },
   "dependencies": {
     "commander": "^2.9.0",
-    "electron": "2.0.4",
-    "rw": "^1.3.2"
+    "electron": "2.0.6",
+    "rw": "^1.3.2",
+    "set-cookie-parser": "^2.2.1"
   },
   "devDependencies": {
     "electron-packager": "^7.0.4"

--- a/cli/src/athenapdf.js
+++ b/cli/src/athenapdf.js
@@ -7,11 +7,15 @@ const rw = require("rw");
 const url = require("url");
 
 const athena = require("commander");
+const setCookie = require("set-cookie-parser");
 const electron = require("electron");
 const app = electron.app;
 const BrowserWindow = electron.BrowserWindow;
 
-const mediaPlugin = fs.readFileSync(path.join(__dirname, "./plugin_media.js"), "utf8");
+const mediaPlugin = fs.readFileSync(
+  path.join(__dirname, "./plugin_media.js"),
+  "utf8"
+);
 
 var bw = null;
 var ses = null;
@@ -19,108 +23,149 @@ var uriArg = null;
 var outputArg = null;
 
 if (!process.defaultApp) {
-    process.argv.unshift("--");
+  process.argv.unshift("--");
 }
 
 const addHeader = (header, arr) => {
-    arr.push(header);
-    return arr;
-}
+  arr.push(header);
+  return arr;
+};
 
 athena
-    .version("2.13.0")
-    .description("convert HTML to PDF via stdin or a local / remote URI")
-    .option("--debug", "show GUI", false)
-    .option("-T, --timeout <seconds>", "seconds before timing out (default: 120)", parseInt)
-    .option("-D, --delay <milliseconds>", "milliseconds delay before saving (default: 200)", parseInt)
-    .option("-P, --pagesize <size>", "page size of the generated PDF (default: A4)", /^(A3|A4|A5|Legal|Letter|Tabloid)$/i, "A4")
-    .option("-M, --margins <marginsType>", "margins to use when generating the PDF (default: standard)", /^(standard|none|minimal)$/i, "standard")
-    .option("-Z --zoom <factor>", "zoom factor for higher scale rendering (default: 1 - represents 100%)", parseInt)
-    .option("-S, --stdout", "write conversion to stdout")
-    .option("-A, --aggressive", "aggressive mode / runs dom-distiller")
-    .option("-B, --bypass", "bypasses paywalls on digital publications (experimental feature)")
-    .option("-H, --http-header <key:value>", "add custom headers to request", addHeader, [])
-    .option("--proxy <url>", "use proxy to load remote HTML")
-    .option("--no-portrait", "render in landscape")
-    .option("--no-background", "omit CSS backgrounds")
-    .option("--no-cache", "disables caching")
-    .option("--ignore-certificate-errors", "ignores certificate errors")
-    .option("--ignore-gpu-blacklist", "Enables GPU in Docker environment")
-    .arguments("<URI> [output]")
-    .action((uri, output) => {
-        uriArg = uri;
-        outputArg = output;
-    })
-    .parse(process.argv);
+  .version("2.13.0")
+  .description("convert HTML to PDF via stdin or a local / remote URI")
+  .option("--debug", "show GUI", false)
+  .option(
+    "-T, --timeout <seconds>",
+    "seconds before timing out (default: 120)",
+    parseInt
+  )
+  .option(
+    "-D, --delay <milliseconds>",
+    "milliseconds delay before saving (default: 200)",
+    parseInt
+  )
+  .option(
+    "-P, --pagesize <size>",
+    "page size of the generated PDF (default: A4)",
+    /^(A3|A4|A5|Legal|Letter|Tabloid)$/i,
+    "A4"
+  )
+  .option(
+    "-M, --margins <marginsType>",
+    "margins to use when generating the PDF (default: standard)",
+    /^(standard|none|minimal)$/i,
+    "standard"
+  )
+  .option(
+    "-Z --zoom <factor>",
+    "zoom factor for higher scale rendering (default: 1 - represents 100%)",
+    parseInt
+  )
+  .option("-S, --stdout", "write conversion to stdout")
+  .option("-A, --aggressive", "aggressive mode / runs dom-distiller")
+  .option(
+    "-B, --bypass",
+    "bypasses paywalls on digital publications (experimental feature)"
+  )
+  .option(
+    "-H, --http-header <key:value>",
+    "add custom headers to request",
+    addHeader,
+    []
+  )
+  .option("--proxy <url>", "use proxy to load remote HTML")
+  .option("--no-portrait", "render in landscape")
+  .option("--no-background", "omit CSS backgrounds")
+  .option("--no-cache", "disables caching")
+  .option("--ignore-certificate-errors", "ignores certificate errors")
+  .option("--ignore-gpu-blacklist", "Enables GPU in Docker environment")
+  .arguments("<URI> [output]")
+  .action((uri, output) => {
+    uriArg = uri;
+    outputArg = output;
+  })
+  .parse(process.argv);
 
 // Display help information by default
 if (!process.argv.slice(2).length) {
-    athena.outputHelp();
+  athena.outputHelp();
 }
 
 if (!uriArg) {
-    console.error("No URI given. Set the URI to `-` to pipe HTML via stdin.");
-    process.exit(1);
+  console.error("No URI given. Set the URI to `-` to pipe HTML via stdin.");
+  process.exit(1);
 }
 
 // Handle stdin
 if (uriArg === "-") {
-    let base64Html = new Buffer(rw.readFileSync("/dev/stdin", "utf8"), "utf8").toString("base64");
-    uriArg = "data:text/html;base64," + base64Html;
-// Handle local paths
-} else if (!uriArg.toLowerCase().startsWith("http") && !uriArg.toLowerCase().startsWith("chrome://")) {
-    uriArg = url.format({
-        protocol: "file",
-        pathname: path.resolve(uriArg),
-        slashes: true
-    });
+  let base64Html = new Buffer(
+    rw.readFileSync("/dev/stdin", "utf8"),
+    "utf8"
+  ).toString("base64");
+  uriArg = "data:text/html;base64," + base64Html;
+  // Handle local paths
+} else if (
+  !uriArg.toLowerCase().startsWith("http") &&
+  !uriArg.toLowerCase().startsWith("chrome://")
+) {
+  uriArg = url.format({
+    protocol: "file",
+    pathname: path.resolve(uriArg),
+    slashes: true
+  });
 }
 
 // Generate SHA1 hash if no output is specified
 if (!outputArg) {
-    const shasum = crypto.createHash("sha1");
-    shasum.update(uriArg);
-    outputArg = shasum.digest("hex") + ".pdf";
+  const shasum = crypto.createHash("sha1");
+  shasum.update(uriArg);
+  outputArg = shasum.digest("hex") + ".pdf";
 }
 
 // Built-in timeout (exit) when debugging is off
 if (!athena.debug) {
-    setTimeout(() => {
-        console.error("PDF generation timed out.");
-        app.exit(2);
-    }, (athena.timeout || 120) * 1000);
+  setTimeout(() => {
+    console.error("PDF generation timed out.");
+    app.exit(2);
+  }, (athena.timeout || 120) * 1000);
 }
 
 if (athena.proxy) {
-    if (!athena.stdout) {
-        console.info("Using proxy: ", athena.proxy);
-    }
-    app.commandLine.appendSwitch("proxy-server", athena.proxy);
+  if (!athena.stdout) {
+    console.info("Using proxy: ", athena.proxy);
+  }
+  app.commandLine.appendSwitch("proxy-server", athena.proxy);
 }
 
 if (athena.ignoreCertificateErrors) {
-    app.commandLine.appendSwitch("ignore-certificate-errors");
+  app.commandLine.appendSwitch("ignore-certificate-errors");
 }
 
-app.commandLine.appendSwitch('ignore-gpu-blacklist', athena.ignoreGpuBlacklist || "false");
+app.commandLine.appendSwitch(
+  "ignore-gpu-blacklist",
+  athena.ignoreGpuBlacklist || "false"
+);
 
 // Preferences
 var bwOpts = {
-    show: (athena.debug || false),
-    webPreferences: {
-        nodeIntegration: false,
-        webSecurity: false,
-        zoomFactor: (athena.zoom || 1)
-    }
+  show: athena.debug || false,
+  webPreferences: {
+    nodeIntegration: false,
+    webSecurity: false,
+    zoomFactor: athena.zoom || 1
+  },
+  width: 1920,
+  height: 1080
 };
 
 if (process.platform === "linux") {
-    bwOpts["webPreferences"]["defaultFontFamily"] = {
-        standard: "Liberation Serif",
-        serif: "Liberation Serif",
-        sansSerif: "Liberation Sans",
-        monospace: "Liberation Mono"
-    };
+  bwOpts["webPreferences"]["defaultFontFamily"] = {
+    standard: "Liberation Serif",
+    serif: "Liberation Serif",
+    sansSerif: "Liberation Sans",
+    monospace: "Liberation Mono"
+  };
 }
 
 // Add custom headers if specified
@@ -128,129 +173,163 @@ var extraHeaders = athena.httpHeader;
 
 // Toggle cache headers
 if (!athena.cache) {
-    extraHeaders.push("pragma: no-cache");
+  extraHeaders.push("pragma: no-cache");
 }
 const loadOpts = {
-    "extraHeaders": extraHeaders.join("\n")
+  extraHeaders: extraHeaders.join("\n")
 };
 
 // Enum for Electron's marginType codes
 const MarginEnum = {
-  "standard": 0,
-  "none": 1,
-  "minimal": 2,
+  standard: 0,
+  none: 1,
+  minimal: 2
 };
 
 const pdfOpts = {
-    pageSize: athena.pagesize,
-    marginsType: MarginEnum[athena.margins],
-    printBackground: athena.background,
-    landscape: !athena.portrait
+  pageSize: athena.pagesize,
+  marginsType: MarginEnum[athena.margins],
+  printBackground: athena.background,
+  landscape: !athena.portrait
 };
 
 // Utils
 const _complete = () => {
-    if (!athena.stdout) {
-        console.timeEnd("PDF Conversion");
-    }
-    athena.debug || app.quit();
+  if (!athena.stdout) {
+    console.timeEnd("PDF Conversion");
+  }
+  athena.debug || app.quit();
 };
 
-const _output = (data) => {
-    const outputPath = path.join(process.cwd(), outputArg);
-    if (athena.stdout) {
-        process.stdout.write(data, _complete);
-    } else {
-        fs.writeFile(outputPath, data, (err) => {
-            if (err) console.error(err);
-            console.info(`Converted '${uriArg}' to PDF: '${outputArg}'`);
-            _complete();
-        });
-    }
+const _output = data => {
+  const outputPath = path.join(process.cwd(), outputArg);
+  if (athena.stdout) {
+    process.stdout.write(data, _complete);
+  } else {
+    fs.writeFile(outputPath, data, err => {
+      if (err) console.error(err);
+      console.info(`Converted '${uriArg}' to PDF: '${outputArg}'`);
+      _complete();
+    });
+  }
 };
 
 app.on("ready", () => {
-    if (!athena.stdout) {
-        console.time("PDF Conversion");
-    }
-    bw = new BrowserWindow(bwOpts);
+  if (!athena.stdout) {
+    console.time("PDF Conversion");
+  }
+  bw = new BrowserWindow(bwOpts);
 
-    bw.on("closed", () => {
-        bw = null;
-        ses = null;
-    });
+  bw.on("closed", () => {
+    bw = null;
+    ses = null;
+  });
 
-    bw.loadURL(uriArg, loadOpts);
+  bw.loadURL(uriArg, loadOpts);
 
-    ses = bw.webContents.session;
-    if (athena.bypass) {
-        const _cookieWhitelist = ["nytimes", "ft.com"];
-        const _inCookieWhitelist = (url) => {
-            let matches = _cookieWhitelist.filter((safe) => {
-                return url.indexOf(safe) !== -1;
-            });
-            return (matches.length !== 0);
-        };
-        ses.webRequest.onBeforeSendHeaders((details, callback) => {
-            if (details.resourceType === "mainFrame") {
-                if (!_inCookieWhitelist(details.url)) {
-                   delete details.requestHeaders["Cookie"];
-                }
-                details.requestHeaders["Referer"] = "https://www.google.com/";
-                details.requestHeaders["User-Agent"] = "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)";
-            }
-            callback({cancel: false, requestHeaders: details.requestHeaders});
-        });
-    }
-
-    ses.on("will-download", (e, item, webContents) => {
-        e.preventDefault();
-        console.error(`Unable to convert an octet-stream, use stdin.`);
-        app.exit(1);
-    });
-
-    bw.webContents.on("did-fail-load", (e, code, desc, url, isMainFrame) => {
-        if (parseInt(code, 10) >= -3) return;
-        console.error(`Failed to load: ${code} ${desc} (${url})`);
-        if (isMainFrame) {
-            app.exit(1);
+  ses = bw.webContents.session;
+  if (athena.bypass) {
+    const _cookieWhitelist = ["nytimes", "ft.com"];
+    const _inCookieWhitelist = url => {
+      let matches = _cookieWhitelist.filter(safe => {
+        return url.indexOf(safe) !== -1;
+      });
+      return matches.length !== 0;
+    };
+    ses.webRequest.onBeforeSendHeaders((details, callback) => {
+      if (details.resourceType === "mainFrame") {
+        if (!_inCookieWhitelist(details.url)) {
+          delete details.requestHeaders["Cookie"];
         }
+        details.requestHeaders["Referer"] = "https://www.google.com/";
+        details.requestHeaders["User-Agent"] =
+          "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)";
+      }
+      callback({ cancel: false, requestHeaders: details.requestHeaders });
     });
+  }
 
-    bw.webContents.on("did-get-response-details", (e, status, newURL, originalURL, httpResponseCode, requestMethod, referrer, headers, resourceType) => {
-        if (httpResponseCode >= 400) {
-            console.error(`Failed to load ${newURL} - got HTTP code ${httpResponseCode}`);
-            if (resourceType === "mainFrame") {
-                app.exit(1);
-            }
+  ses.on("will-download", (e, item, webContents) => {
+    e.preventDefault();
+    console.error(`Unable to convert an octet-stream, use stdin.`);
+    app.exit(1);
+  });
+
+  const cookieHeaders = athena.httpHeader
+    .filter(header => header.includes("Cookie:"))
+    .map(header =>
+      header.substring(header.indexOf("Cookie:") + "Cookie:".length).trim()
+    );
+  if (cookieHeaders) {
+    setCookie.parse(cookieHeaders, { decodeValues: false }).forEach(cookie => {
+      ses.cookies.set(Object.assign(cookie, { url: uriArg }), error => {
+        if (error) {
+          console.error(error);
         }
+      });
     });
+  }
 
-    bw.webContents.on("crashed", () => {
-        console.error(`The renderer process has crashed.`);
-        app.exit(1);
-    });
-
-    // Load plugins
-    let plugins = mediaPlugin + "\n";
-    if (athena.aggressive) {
-        const distillerPlugin = fs.readFileSync(path.join(__dirname, "./plugin_domdistiller.js"), "utf8");
-        plugins += distillerPlugin;
+  bw.webContents.on("did-fail-load", (e, code, desc, url, isMainFrame) => {
+    if (parseInt(code, 10) >= -3) return;
+    console.error(`Failed to load: ${code} ${desc} (${url})`);
+    if (isMainFrame) {
+      app.exit(1);
     }
-    bw.webContents.executeJavaScript(plugins);
+  });
 
-    bw.webContents.on("did-finish-load", () => {
-        setTimeout(() => {
-            bw.webContents.printToPDF(pdfOpts, (err, data) => {
-                if (err) console.error(err);
-                _output(data);
-            });
-        }, (athena.delay || 200));
-    });
+  bw.webContents.on(
+    "did-get-response-details",
+    (
+      e,
+      status,
+      newURL,
+      originalURL,
+      httpResponseCode,
+      requestMethod,
+      referrer,
+      headers,
+      resourceType
+    ) => {
+      if (httpResponseCode >= 400) {
+        console.error(
+          `Failed to load ${newURL} - got HTTP code ${httpResponseCode}`
+        );
+        if (resourceType === "mainFrame") {
+          app.exit(1);
+        }
+      }
+    }
+  );
+
+  bw.webContents.on("crashed", () => {
+    console.error(`The renderer process has crashed.`);
+    app.exit(1);
+  });
+
+  // Load plugins
+  let plugins = mediaPlugin + "\n";
+  if (athena.aggressive) {
+    const distillerPlugin = fs.readFileSync(
+      path.join(__dirname, "./plugin_domdistiller.js"),
+      "utf8"
+    );
+    plugins += distillerPlugin;
+  }
+  bw.webContents.executeJavaScript(plugins);
+
+  bw.webContents.on("did-finish-load", () => {
+    setTimeout(() => {
+      bw.webContents.printToPDF(pdfOpts, (err, data) => {
+        if (err) console.error(err);
+        _output(data);
+      });
+    }, athena.delay || 200);
+  });
 });
 
 app.on("window-all-closed", () => {
-    if (process.platform !== "darwin") {
-        app.quit();
-    }
+  if (process.platform !== "darwin") {
+    app.quit();
+  }
 });

--- a/weaver/Dockerfile
+++ b/weaver/Dockerfile
@@ -1,5 +1,5 @@
 FROM arachnysdocker/athenapdf
-MAINTAINER Arachnys <techteam@arachnys.com>
+LABEL maintainer="Arachnys <techteam@arachnys.com>"
 
 ENV GIN_MODE release
 

--- a/weaver/converter/athenapdf/athenapdf.go
+++ b/weaver/converter/athenapdf/athenapdf.go
@@ -1,10 +1,11 @@
 package athenapdf
 
 import (
-	"github.com/arachnys/athenapdf/weaver/converter"
-	"github.com/arachnys/athenapdf/weaver/gcmd"
 	"log"
 	"strings"
+
+	"github.com/arachnys/athenapdf/weaver/converter"
+	"github.com/arachnys/athenapdf/weaver/gcmd"
 )
 
 // AthenaPDF represents a conversion job for athenapdf CLI.
@@ -29,11 +30,15 @@ type AthenaPDF struct {
 // string.
 // It will set an additional '-A' flag if aggressive is set to true.
 // See athenapdf CLI for more information regarding the aggressive mode.
-func constructCMD(base string, path string, aggressive bool) []string {
+func constructCMD(base string, path string, headers []string, aggressive bool) []string {
 	args := strings.Fields(base)
 	args = append(args, path)
 	if aggressive {
 		args = append(args, "-A")
+	}
+	for _, header := range headers {
+		args = append(args, "-H")
+		args = append(args, header)
 	}
 	return args
 }
@@ -45,7 +50,7 @@ func (c AthenaPDF) Convert(s converter.ConversionSource, done <-chan struct{}) (
 	log.Printf("[AthenaPDF] converting to PDF: %s\n", s.GetActualURI())
 
 	// Construct the command to execute
-	cmd := constructCMD(c.CMD, s.URI, c.Aggressive)
+	cmd := constructCMD(c.CMD, s.URI, s.Headers, c.Aggressive)
 	out, err := gcmd.Execute(cmd, done)
 	if err != nil {
 		return nil, err

--- a/weaver/converter/source.go
+++ b/weaver/converter/source.go
@@ -1,13 +1,14 @@
 package converter
 
 import (
-	"golang.org/x/net/publicsuffix"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"net/http/cookiejar"
 	"os"
 	"path/filepath"
+
+	"golang.org/x/net/publicsuffix"
 )
 
 // ConversionSource contains the target resource path, and its MIME type.
@@ -30,6 +31,9 @@ type ConversionSource struct {
 	// and false if the target is a remote source (that does not require
 	// pre-processing).
 	IsLocal bool
+	// Headers are for the initial request to the URI. If they contain
+	// cookies, those are set for subsequent AJAX requests (with AthenaPDF)
+	Headers []string
 }
 
 // readerContentType attempts to determine the content type using bytes from a
@@ -157,7 +161,7 @@ func setCustomExtension(s *ConversionSource, ext string) error {
 // of bytes. If both parameters are specified, the reader takes precedence.
 // The ConversionSource is prepared using one of two strategies: a local
 // conversion (see rawSource) or a remote conversion (see uriSource).
-func NewConversionSource(uri string, body io.Reader, ext string) (*ConversionSource, error) {
+func NewConversionSource(uri string, headers []string, body io.Reader, ext string) (*ConversionSource, error) {
 	s := new(ConversionSource)
 
 	var err error
@@ -165,6 +169,7 @@ func NewConversionSource(uri string, body io.Reader, ext string) (*ConversionSou
 		err = rawSource(s, body)
 	} else {
 		err = uriSource(s, uri)
+		s.Headers = headers
 	}
 
 	if err != nil {

--- a/weaver/converter/source_test.go
+++ b/weaver/converter/source_test.go
@@ -258,7 +258,7 @@ func TestNewConversionSource(t *testing.T) {
 	mockURI := "http://this-should-not-be-used"
 	mockData := "<!DOCTYPE HTML>"
 	mockReader := strings.NewReader(mockData)
-	s, err := NewConversionSource(mockURI, mockReader, "")
+	s, err := NewConversionSource(mockURI, [], mockReader, "")
 	if err != nil {
 		t.Fatalf("newconversionsource returned an unexpected error: %+v", err)
 	}
@@ -268,7 +268,7 @@ func TestNewConversionSource(t *testing.T) {
 func TestNewConversionSource_remote(t *testing.T) {
 	ts := testutil.MockHTTPServer("", "<?xml version=\"1.0\" encoding=\"UTF-8\"?>", false)
 	defer ts.Close()
-	s, err := NewConversionSource(ts.URL, nil, "")
+	s, err := NewConversionSource(ts.URL, [], nil, "")
 	if err != nil {
 		t.Fatalf("newconversionsource returned an unexpected error: %+v", err)
 	}
@@ -276,7 +276,7 @@ func TestNewConversionSource_remote(t *testing.T) {
 }
 
 func TestNewConversionSource_invalidURL(t *testing.T) {
-	s, err := NewConversionSource("http://invalid-url", nil, "")
+	s, err := NewConversionSource("http://invalid-url", [], nil, "")
 	if err == nil {
 		t.Fatalf("expected error to be returned")
 	}

--- a/weaver/converter/upload_conversion.go
+++ b/weaver/converter/upload_conversion.go
@@ -2,13 +2,15 @@ package converter
 
 import (
 	"bytes"
+	"log"
+	"os"
+	"time"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
-	"log"
-	"time"
 )
 
 type AWSS3 struct {
@@ -23,6 +25,19 @@ type AWSS3 struct {
 type UploadConversion struct {
 	Conversion
 	AWSS3
+}
+
+func NewS3(region string, accessKey string, accessSecret string, bucket string, bucketKey string, acl string) AWSS3 {
+	if region == "" {
+		region = os.Getenv("AWS_REGION")
+	}
+	if accessKey == "" {
+		accessKey = os.Getenv("AWS_ACCESS_KEY")
+	}
+	if accessSecret == "" {
+		accessSecret = os.Getenv("AWS_SECRET")
+	}
+	return AWSS3{region, accessKey, accessSecret, bucket, bucketKey, acl}
 }
 
 func uploadToS3(awsConf AWSS3, b []byte) error {


### PR DESCRIPTION
This allows session emulation so this can be used as part of a script
to act as a logged-in user (for pages without CSRF protections).

The athenapdf file was mangled by my editor's default formatting settings,
but I'm putting this up to see if there any interest in this kind of feature.
I don't know if this is supported in v3 or if this is portable as I haven't looked at that branch.

I also made some quality of life improvements for those running this with a single internal AWS account.