### PR TITLE
Add landscape and page size support to weaver

### DIFF
--- a/weaver/converter/athenapdf/athenapdf.go
+++ b/weaver/converter/athenapdf/athenapdf.go
@@ -22,6 +22,11 @@ type AthenaPDF struct {
 	// an '-A' command-line flag to indicate aggressive content extraction
 	// (ideal for a clutter-free reading experience).
 	Aggressive bool
+	// NoPortrait will set the output PDF to be in landscape instead of in
+	// portrait orientation
+	NoPortrait bool
+	// Sets the page size for the PDF
+	PageSize string
 }
 
 // constructCMD returns a string array containing the AthenaPDF command to be
@@ -29,11 +34,17 @@ type AthenaPDF struct {
 // string.
 // It will set an additional '-A' flag if aggressive is set to true.
 // See athenapdf CLI for more information regarding the aggressive mode.
-func constructCMD(base string, path string, aggressive bool) []string {
+func constructCMD(base string, path string, aggressive bool, noPortrait bool, pageSize string) []string {
 	args := strings.Fields(base)
 	args = append(args, path)
 	if aggressive {
 		args = append(args, "-A")
+	}
+	if noPortrait {
+		args = append(args, "--no-portrait")
+	}
+	if len(pageSize) > 0 {
+		args = append(args, "-P", pageSize);
 	}
 	return args
 }
@@ -45,7 +56,7 @@ func (c AthenaPDF) Convert(s converter.ConversionSource, done <-chan struct{}) (
 	log.Printf("[AthenaPDF] converting to PDF: %s\n", s.GetActualURI())
 
 	// Construct the command to execute
-	cmd := constructCMD(c.CMD, s.URI, c.Aggressive)
+	cmd := constructCMD(c.CMD, s.URI, c.Aggressive, c.NoPortrait, c.PageSize)
 	out, err := gcmd.Execute(cmd, done)
 	if err != nil {
 		return nil, err

--- a/weaver/converter/athenapdf/athenapdf_test.go
+++ b/weaver/converter/athenapdf/athenapdf_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestConstructCMD(t *testing.T) {
-	got := constructCMD("athenapdf -S -T 120", "test_file.html", false)
+	got := constructCMD("athenapdf -S -T 120", "test_file.html", false, false, "")
 	want := []string{"athenapdf", "-S", "-T", "120", "test_file.html"}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("expected constructed athenapdf command to be %+v, got %+v", want, got)
@@ -18,9 +18,24 @@ func TestConstructCMD(t *testing.T) {
 }
 
 func TestConstructCMD_aggressive(t *testing.T) {
-	cmd := constructCMD("athenapdf -S -T 60", "test_file.html", true)
+	cmd := constructCMD("athenapdf -S -T 60", "test_file.html", true, false, "")
 	if got, want := cmd[len(cmd)-1], "-A"; got != want {
 		t.Errorf("expected last argument of constructed athenapdf command to be %s, got %+v", want, got)
+	}
+}
+
+func TestConstructCMD_landscape(t *testing.T) {
+	cmd := constructCMD("athenapdf -S -T 60", "test_file.html", false, true, "")
+	if got, want := cmd[len(cmd)-1], "--no-portrait"; got != want {
+		t.Errorf("expected last argument of constructed athenapdf command to be %s, got %+v", want, got)
+	}
+}
+
+func TestConstructCMD_pageSizeA3(t *testing.T) {
+	got := constructCMD("athenapdf -S -T 60", "test_file.html", false, false, "A3")
+	want := []string{"athenapdf", "-S", "-T", "60", "test_file.html", "-P", "A3"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("expected constructed athenapdf command to be %+v, got %+v", want, got)
 	}
 }
 

--- a/weaver/handlers.go
+++ b/weaver/handlers.go
@@ -48,6 +48,8 @@ func conversionHandler(c *gin.Context, source converter.ConversionSource) {
 	}
 
 	_, aggressive := c.GetQuery("aggressive")
+	_, noPortrait := c.GetQuery("no_portrait")
+	pageSize := c.Query("page_size")
 
 	conf := c.MustGet("config").(Config)
 	wq := c.MustGet("queue").(chan<- converter.Work)
@@ -73,7 +75,7 @@ func conversionHandler(c *gin.Context, source converter.ConversionSource) {
 	uploadConversion := converter.UploadConversion{baseConversion, awsConf}
 
 StartConversion:
-	conversion = athenapdf.AthenaPDF{uploadConversion, conf.AthenaCMD, aggressive}
+	conversion = athenapdf.AthenaPDF{uploadConversion, conf.AthenaCMD, aggressive, noPortrait, pageSize}
 	if attempts != 0 {
 		cc := cloudconvert.Client{
 			conf.CloudConvert.APIUrl,


### PR DESCRIPTION
Weaver doesn't support setting the page size and the page orientation to the cli.

On a related side note the cli's switch for the page orientation is not the same as wkhtmltopdf's so that prevents it from being a drop in replacement.