### PR TITLE
check if /etc/hosts is writeable before adding bad hosts

### DIFF
--- a/weaver/conf/entrypoint.sh
+++ b/weaver/conf/entrypoint.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 set -e
 
-# Block bad hosts
-cat conf/hosts >> /etc/hosts
+# Block bad hosts, if /etc/hosts is writeable
+if [ -w /etc/hosts ]; then
+   cat conf/hosts >> /etc/hosts
+fi
 
 rm -f /tmp/.X99-lock
 export DISPLAY=:99


### PR DESCRIPTION
this solves issues with some Kubernetes environments where /etc/hosts is write protected