### PR TITLE
fixed typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ The microservice can be deployed scalably to [ECS][ecs] if you want to build you
 
 ## License
 
-Please note `athenapdf` is NEITHER affiliated with NOR endorsed by Google Inc. and GitHub Inc.
+Please note `athenapdf` is NEITHER affiliated with NOR endorsed by Google Inc. or GitHub Inc.
 
 See [`LICENSE`](LICENSE).
 


### PR DESCRIPTION
Per DeMorgan's laws, ~(a^b) == ~a v ~b.
In other words, not Google AND GitHub is the same as not Google or not GitHub.
~(avb) == ~a ^ ~b.
not Google OR GitHub is the same as not Google and not GitHub.